### PR TITLE
Fix asset hash error to enable correct jpg signing

### DIFF
--- a/tc_c2pa_py/c2pa/assertion.py
+++ b/tc_c2pa_py/c2pa/assertion.py
@@ -38,7 +38,7 @@ class HashDataAssertion(Assertion):
 
     def __init__(self, cai_offset, hashed_data, additional_exclusions):
         hash_data_schema = {
-            "exclusions": [{"start": cai_offset, "length": -1}] + additional_exclusions, # set length to 65535, library will calculate length by itself
+            "exclusions": [{"start": cai_offset, "length": 65535}] + additional_exclusions, # set length to 65535, library will calculate length by itself
             "name": "jumbf manifest",
             "alg": "sha256",
             "hash": hashed_data,
@@ -51,7 +51,7 @@ class HashDataAssertion(Assertion):
     def set_hash_data_length(self, length):
         if self.schema['name'] == 'jumbf manifest':
             for exclusion_id in range(len(self.schema['exclusions'])):
-                if self.schema['exclusions'][exclusion_id]['length'] == -1:
+                if self.schema['exclusions'][exclusion_id]['length'] == 65535:
                     self.schema['exclusions'][exclusion_id]['length'] = length
         
         self.payload = self.get_payload_from_schema()

--- a/tc_c2pa_py/c2pa/claim.py
+++ b/tc_c2pa_py/c2pa/claim.py
@@ -20,7 +20,7 @@ class Claim(SuperBox):
 
         content_boxes = self.generate_payload()
         
-        super().__init__(label="c2pa.claim", content_type=c2pa_content_types["claim"], content_boxes=content_boxes)
+        super().__init__(label="c2pa.claim.v2", content_type=c2pa_content_types["claim"], content_boxes=content_boxes)
     
     
     def generate_payload(self):


### PR DESCRIPTION
Jpeg images were generating with the following errors:

```bash
"failure": [

        {

          "code": "claimSignature.mismatch",

          "url": "self#jumbf=/c2pa/tc_c2pa_py:urn:uuid:7ac1fe13-d158-4420-a12d-34eec6e5d0bf/c2pa.signature",

          "explanation": "claim signature is not valid"

        },

        {

          "code": "assertion.dataHash.mismatch",

          "url": "self#jumbf=/c2pa/tc_c2pa_py:urn:uuid:7ac1fe13-d158-4420-a12d-34eec6e5d0bf/c2pa.assertions/c2pa.hash.data",

          "explanation": "asset hash error, name: jumbf manifest, error: hash verification( Hashes do not match )"

        }
]
```

The last error means that something is wrong with hash assertion. It can be fixed by changing default data of exclusions length. 
The second error isn't really a problem. It just indicates that our current certificates are not trust worthy. We should fix that later.